### PR TITLE
Fixed bug when regex is '.'

### DIFF
--- a/xeger/xeger.py
+++ b/xeger/xeger.py
@@ -16,7 +16,7 @@ if sys.version_info[0] >= 3:
     xrange = range
 
 
-class Xeger(object):
+class Xeger(object):
     def __init__(self, limit=10):
         super(Xeger, self).__init__()
         self._limit = limit

--- a/xeger/xeger.py
+++ b/xeger/xeger.py
@@ -16,7 +16,7 @@ if sys.version_info[0] >= 3:
     xrange = range
 
 
-class Xeger(object):
+class Xeger(object):
     def __init__(self, limit=10):
         super(Xeger, self).__init__()
         self._limit = limit
@@ -58,7 +58,7 @@ class Xeger(object):
                 lambda x: choice(string.printable.replace(unichr(x), '')),
             "at": lambda x: '',
             "in": lambda x: self._handle_in(x),
-            "any": lambda x: string.printable.replace('\n', ''),
+            "any": lambda x: choice(string.printable.replace('\n', '')),
             "range": lambda x: [unichr(i) for i in xrange(x[0], x[1] + 1)],
             "category": lambda x: self._categories[x](),
             'branch':


### PR DESCRIPTION
Regex with '.'  would return all of string.printable
