### PR TITLE
Handle regex qualifier incoherent with Xeger limit

### DIFF
--- a/xeger/tests/test_xeger.py
+++ b/xeger/tests/test_xeger.py
@@ -147,6 +147,13 @@ def test_zero_or_more_non_greedy():
     match(r'a*?')
 
 
+@pytest.mark.parametrize("limit", range(5))
+def test_incoherent_limit_and_qualifier(limit):
+    r = xeger.Xeger(limit=limit)
+    o = r.xeger(r'a{2}')
+    assert len(o) == 2
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-vv'])
 

--- a/xeger/xeger.py
+++ b/xeger/xeger.py
@@ -113,7 +113,7 @@ class Xeger(object):
     def _handle_repeat(self, start_range, end_range, value):
         result = []
         end_range = min((end_range, self._limit))
-        times = randint(start_range, end_range)
+        times = randint(start_range, max(start_range, end_range))
         for i in xrange(times):
             result.append(''.join(self._handle_state(i) for i in value))
         return ''.join(result)


### PR DESCRIPTION
Handle regex qualifier incoherent with Xeger limit. 
Useful when mixing greedy operator with small limit (ex: limit=5) and explicit qualifier like {12,16}.
Fix the issue #6 .

I do think it should not raise an assertion error, probably a warning log would be useful.
