### PR TITLE
sre_parse fix

### DIFF
--- a/xeger/xeger.py
+++ b/xeger/xeger.py
@@ -14,7 +14,10 @@ from random import Random
 if sys.version_info[0] >= 3:
     unichr = chr
     xrange = range
-
+try:
+    import sre_parse
+except ImportError:
+    sre_parse = re.sre_parse
 
 class Xeger(object):
     def __init__(self, limit=10, seed=None):
@@ -84,7 +87,7 @@ class Xeger(object):
         except AttributeError:
             pattern = string_or_regex
 
-        parsed = re.sre_parse.parse(pattern)
+        parsed = sre_parse.parse(pattern)
         result = self._build_string(parsed)
         self._cache.clear()
         return result


### PR DESCRIPTION
Avoiding the following error:
```py
>>> from xeger import xeger
>>> xeger(r"[1-9]\d{14}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/lib/python3.11/site-packages/xeger/xeger.py", line 87, in xeger
    parsed = re.sre_parse.parse(pattern)
             ^^^^^^^^^^^^
AttributeError: module 're' has no attribute 'sre_parse'
```
`sre_parser` have been moved out of the `re` module, and is now a package by itself ([commit here](https://github.com/python/cpython/commit/1be3260a90f16aae334d993aecf7b70426f98013))